### PR TITLE
Check for Nullable types

### DIFF
--- a/src/JsonMapper.php
+++ b/src/JsonMapper.php
@@ -112,6 +112,14 @@ class JsonMapper
                 );
                 continue;
             }
+            
+            if ($this->isNullable($type)) {
+                if ($jvalue === null) {
+                    $this->setProperty($object, $key, null, $setter);
+                    continue;
+                }
+                $type = $this->removeNullable($type);
+            }
 
             if ($type === null) {
                 //no given type - simply set the json data
@@ -384,6 +392,35 @@ class JsonMapper
             || $type == 'boolean' || $type == 'bool'
             || $type == 'integer' || $type == 'int'
             || $type == 'float';
+    }
+    
+    /**
+     * Checks if the given type is nullable
+     *
+     * @param string $type type name from the phpdoc param
+     *
+     * @return boolean True if it is nullable
+     */
+    protected function isNullable($type)
+    {
+        return in_array('null', explode('|', strtolower($type)));
+    }
+
+    /**
+     * Remove the nullable section of a type
+     *
+     * @param string $type type name from the phpdoc param
+     *
+     * @return string The new type value
+     */
+    protected function removeNullable($type)
+    {
+        if (strtolower($type) === 'null') {
+            return $type;
+        }
+
+        $types = array_udiff(explode('|', $type), ['null'], 'strcasecmp');
+        return implode('|', $types);
     }
 
     /**

--- a/src/JsonMapper.php
+++ b/src/JsonMapper.php
@@ -419,7 +419,7 @@ class JsonMapper
             return $type;
         }
 
-        $types = array_udiff(explode('|', $type), ['null'], 'strcasecmp');
+        $types = array_udiff(explode('|', $type), array('null'), 'strcasecmp');
         return implode('|', $types);
     }
 

--- a/tests/JsonMapperTest.php
+++ b/tests/JsonMapperTest.php
@@ -109,6 +109,34 @@ class JsonMapperTest extends \PHPUnit_Framework_TestCase
         $this->assertInternalType('integer', $sn->pinteger);
         $this->assertEquals(12345, $sn->pinteger);
     }
+    
+    /**
+     * Test for "@var int|null"
+     */
+    public function testMapSimpleNullableInt()
+    {
+        $jm = new JsonMapper();
+        $sn = $jm->map(
+            json_decode('{"pnullable":0}'),
+            new JsonMapperTest_Simple()
+        );
+        $this->assertInternalType('integer', $sn->pnullable);
+        $this->assertEquals(0, $sn->pnullable);
+    }
+    
+    /**
+     * Test for "@var int|null"
+     */
+    public function testMapSimpleNullableNull()
+    {
+        $jm = new JsonMapper();
+        $sn = $jm->map(
+            json_decode('{"pnullable":null}'),
+            new JsonMapperTest_Simple()
+        );
+        $this->assertInternalType('null', $sn->pnullable);
+        $this->assertEquals(null, $sn->pnullable);
+    }
 
     /**
      * Test for variable with no @var annotation

--- a/tests/JsonMapperTest.php
+++ b/tests/JsonMapperTest.php
@@ -111,7 +111,7 @@ class JsonMapperTest extends \PHPUnit_Framework_TestCase
     }
     
     /**
-     * Test for "@var int|null"
+     * Test for "@var int|null" with int value
      */
     public function testMapSimpleNullableInt()
     {
@@ -125,7 +125,7 @@ class JsonMapperTest extends \PHPUnit_Framework_TestCase
     }
     
     /**
-     * Test for "@var int|null"
+     * Test for "@var int|null" with null value
      */
     public function testMapSimpleNullableNull()
     {
@@ -136,6 +136,20 @@ class JsonMapperTest extends \PHPUnit_Framework_TestCase
         );
         $this->assertInternalType('null', $sn->pnullable);
         $this->assertEquals(null, $sn->pnullable);
+    }
+    
+    /**
+     * Test for "@var int|null" with string value
+     */
+    public function testMapSimpleNullableWrong()
+    {
+        $jm = new JsonMapper();
+        $sn = $jm->map(
+            json_decode('{"pnullable":"12345"}'),
+            new JsonMapperTest_Simple()
+        );
+        $this->assertInternalType('integer', $sn->pnullable);
+        $this->assertEquals(12345, $sn->pnullable);
     }
 
     /**

--- a/tests/JsonMapperTest/Simple.php
+++ b/tests/JsonMapperTest/Simple.php
@@ -41,6 +41,11 @@ class JsonMapperTest_Simple
      * @var integer
      */
     public $pinteger;
+    
+    /**
+     * @var int|null
+     */
+    public $pnullable;
 
     /**
      * @var float


### PR DESCRIPTION
Sometimes I want to cast a value to an int or string, but if the original value is null, I would like to get that. So I would typehint that as `int|null` or `string|null` or something.

This PR adds a check for a 'nullable' typehint, eg. when `null` is one of the options. When the type is nullable and the value is null, the property is set to null. When the type is not null, the nullable typehint is removed from the type, so that is can be matched to a class or simpletype. (So `int|null` becomes `int`)

This might not be the best way to do this (exploding, array_diffing etc), but I did this because I want to allow for multiple cases (`int|null`, `int|NULL` should match, `NullType` should not, only `null` should be nullable but return `null` as type still etc)