### PR TITLE
Convert snake case setters to camel case.

### DIFF
--- a/src/JsonMapper.php
+++ b/src/JsonMapper.php
@@ -307,7 +307,7 @@ class JsonMapper
         }
 
         // Parameter could not be directly set, so lets go for setter methods
-        $setter = 'set' . ucfirst($name);
+        $setter = 'set' . preg_replace('/(?:^|_)(.?)/e',"strtoupper('$1')",$name);
 
         if (!$rc->hasMethod($setter)) {
             if ($rc->hasProperty($name)) {

--- a/src/JsonMapper.php
+++ b/src/JsonMapper.php
@@ -307,7 +307,7 @@ class JsonMapper
         }
 
         // Parameter could not be directly set, so lets go for setter methods
-        $setter = 'set' . preg_replace('/(?:^|_)(.?)/e',"strtoupper('$1')",$name);
+        $setter = 'set' . str_replace(' ', '', ucwords(str_replace('_', ' ', $name)));
 
         if (!$rc->hasMethod($setter)) {
             if ($rc->hasProperty($name)) {


### PR DESCRIPTION
Changing the way library was looking for setter methods. 
Previously it was concatenating 'set' with ucfirst($name). This way, if the incoming json had an attribute written in snake case like "number_of_comments", it'd look for a method called setNumber_of_comments, which does not follow the PSR-1 convention. 
With this change, it now converts the name of the json attribute to camel case, and looks for the correct setter method. 