### PR TITLE
Fix NS error

### DIFF
--- a/src/JsonMapper.php
+++ b/src/JsonMapper.php
@@ -299,7 +299,7 @@ class JsonMapper
                 if (count($rparams) > 0) {
                     $pclass = $rparams[0]->getClass();
                     if ($pclass !== null) {
-                        return array(true, true, $pclass->getName(), $rmeth);
+                        return array(true, true, '\\'.$pclass->getName(), $rmeth);
                     }
                 }
 


### PR DESCRIPTION
When using the setter option, ReflectionParameter::getClass()->getName() gives you the full namespace name for type hinting class. My fix solves the issue of concatenating the actual namespace with that ns, since getName() doesn't return a \ before the name.