### PR TITLE
Allow to pass objects to setters

### DIFF
--- a/src/JsonMapper.php
+++ b/src/JsonMapper.php
@@ -385,12 +385,12 @@ class JsonMapper
     }
 
     /**
-     * Checks if the given object is of this type or has this type as one of its parents
+     * Checks if the object is of this type or has this type as one of its parents
      *
-     * @param string $type
-     * @param mixed $object
+     * @param string $type   class name of type being required
+     * @param mixed  $object object instance to be tested
      *
-     * @return boolean
+     * @return boolean True if $object has type of $type
      */
     protected function isObjectOfSameType($type, $object)
     {

--- a/src/JsonMapper.php
+++ b/src/JsonMapper.php
@@ -121,7 +121,10 @@ class JsonMapper
                 $type = $this->removeNullable($type);
             }
 
-            if ($type === null || $type === 'mixed') {
+            if ($this->isSameType($type, $jvalue)) {
+                $this->setProperty($object, $key, $jvalue, $setter);
+                continue;
+            } else if ($type === null || $type === 'mixed') {
                 //no given type - simply set the json data
                 $this->setProperty($object, $key, $jvalue, $setter);
                 continue;
@@ -379,6 +382,24 @@ class JsonMapper
             || $type == 'boolean' || $type == 'bool'
             || $type == 'integer' || $type == 'int'
             || $type == 'float' || $type == 'array' || $type == 'object';
+    }
+
+    /**
+     * Checks if the given object is of this type or has this type as one of its parents
+     *
+     * @param string $type
+     * @param mixed $object
+     *
+     * @return boolean
+     */
+    protected function isSameType($type, $object)
+    {
+
+        if (false === is_object($object)) {
+            return false;
+        }
+
+        return is_a($object, $type);
     }
 
     /**

--- a/src/JsonMapper.php
+++ b/src/JsonMapper.php
@@ -121,11 +121,11 @@ class JsonMapper
                 $type = $this->removeNullable($type);
             }
 
-            if ($this->isSameType($type, $jvalue)) {
+            if ($type === null || $type === 'mixed') {
+                //no given type - simply set the json data
                 $this->setProperty($object, $key, $jvalue, $setter);
                 continue;
-            } else if ($type === null || $type === 'mixed') {
-                //no given type - simply set the json data
+            } else if ($this->isObjectOfSameType($type, $jvalue)) {
                 $this->setProperty($object, $key, $jvalue, $setter);
                 continue;
             } else if ($this->isSimpleType($type)) {
@@ -392,7 +392,7 @@ class JsonMapper
      *
      * @return boolean
      */
-    protected function isSameType($type, $object)
+    protected function isObjectOfSameType($type, $object)
     {
 
         if (false === is_object($object)) {

--- a/tests/JsonMapperTest.php
+++ b/tests/JsonMapperTest.php
@@ -14,6 +14,7 @@ require_once 'JsonMapperTest/Broken.php';
 require_once 'JsonMapperTest/Simple.php';
 require_once 'JsonMapperTest/Logger.php';
 require_once 'JsonMapperTest/PrivateWithSetter.php';
+require_once 'JsonMapperTest/ValueObject.php';
 
 /**
  * Unit tests for JsonMapper
@@ -604,6 +605,18 @@ class JsonMapperTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(
             'set via setter: foo', $sn->setterPreferredOverProperty
         );
+    }
+
+    public function testSettingValueObjects()
+    {
+        $valueObject = new JsonMapperTest_ValueObject('test');
+        $jm = new JsonMapper();
+        $sn = $jm->map(
+            array('value_object' => $valueObject),
+            new JsonMapperTest_Simple()
+        );
+
+        $this->assertSame($valueObject, $sn->getValueObject());
     }
 }
 ?>

--- a/tests/JsonMapperTest/Simple.php
+++ b/tests/JsonMapperTest/Simple.php
@@ -128,6 +128,12 @@ class JsonMapperTest_Simple
      */
     public $setterPreferredOverProperty;
 
+    /**
+     * Value object which needs to be set as an instance (without mapping)
+     * @var JsonMapperTest_ValueObject
+     */
+    public $valueObject;
+
     public function setSimpleSetterOnlyTypeHint(JsonMapperTest_Simple $s)
     {
         $this->internalData['typehint'] = $s;
@@ -159,6 +165,22 @@ class JsonMapperTest_Simple
     public function setSetterPreferredOverProperty($v)
     {
         $this->setterPreferredOverProperty = 'set via setter: ' . $v;
+    }
+
+    /**
+     * @return JsonMapperTest_ValueObject
+     */
+    public function getValueObject()
+    {
+        return $this->valueObject;
+    }
+
+    /**
+     * @param JsonMapperTest_ValueObject $valueObject
+     */
+    public function setValueObject(JsonMapperTest_ValueObject $valueObject)
+    {
+        $this->valueObject = $valueObject;
     }
 }
 ?>

--- a/tests/JsonMapperTest/ValueObject.php
+++ b/tests/JsonMapperTest/ValueObject.php
@@ -1,0 +1,12 @@
+<?php
+
+class JsonMapperTest_ValueObject
+{
+
+    protected $value;
+
+    public function __construct($value)
+    {
+        $this->value = $value;
+    }
+}


### PR DESCRIPTION
This PR is related to #35. 

If processed value is instance of the same class required by setter `JsonMapper::map()` will simply pass it to setter.